### PR TITLE
fixed overflow of mouse coordinates

### DIFF
--- a/draw/mouse.go
+++ b/draw/mouse.go
@@ -50,7 +50,7 @@ func mouseproc(mc *Mousectl, d *Display, ch chan Mouse, rch chan bool) {
 		if resized {
 			rch <- true
 		}
-		mm := Mouse{image.Point{m.X, m.Y}, m.Buttons, uint32(m.Msec)}
+		mm := Mouse{image.Point{int(int32(m.X)), int(int32(m.Y))}, m.Buttons, uint32(m.Msec)}
 		ch <- mm
 		/*
 		 * See comment above.


### PR DESCRIPTION
When a mouse button is down, mouse events may come from outside the window. This means mouse coordinates may be negative. On my system (amd64), I got numbers close to 2^32 instead. By converting the (possibly) 64-bit coordinates to 32-bit and back, I get the right values.
