### PR TITLE
plan9/client: Set tag=NOTAG in initial version message.

### DIFF
--- a/plan9/client/conn.go
+++ b/plan9/client/conn.go
@@ -38,9 +38,12 @@ func NewConn(rwc io.ReadWriteCloser) (*Conn, error) {
 		version: "9P2000",
 	}
 
-	//	XXX raw messages, not c.rpc
-	tx := &plan9.Fcall{Type: plan9.Tversion, Msize: c.msize, Version: c.version}
-	rx, err := c.rpc(tx)
+	tx := &plan9.Fcall{Type: plan9.Tversion, Tag: plan9.NOTAG, Msize: c.msize, Version: c.version}
+	err := c.write(tx)
+	if err != nil {
+		return nil, err
+	}
+	rx, err := c.read()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The version(5) man page says the tag should be set to NOTAG.
Calling rpc() sets the tag to 1. (With this patch, plan9/client works
with servers written with go9p.)
