### PR TITLE
plan9/client: Add ReadByte method to implement ByteReader interface

### DIFF
--- a/plan9/client/fid.go
+++ b/plan9/client/fid.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -106,6 +107,18 @@ func (fid *Fid) Qid() plan9.Qid {
 
 func (fid *Fid) Read(b []byte) (n int, err error) {
 	return fid.ReadAt(b, -1)
+}
+
+func (fid *Fid) ReadByte() (c byte, err error) {
+	b := make([]byte, 1)
+	n, err := fid.Read(b)
+	if err != nil {
+		return 0, err
+	}
+	if n == 0 {
+		return 0, fmt.Errorf("Unknown error reading byte")
+	}
+	return b[0], nil
 }
 
 func (fid *Fid) ReadAt(b []byte, offset int64) (n int, err error) {


### PR DESCRIPTION
plumb.Recv expects an io.ByteReader, but the client.Fid type returned
from plumb.Open doesn't implement the ReadByte method, making it impossible
to receive plumber messages using 9fans.net/go/plumb.

This adds a small wrapper around Read() to read a single byte and return it,
thereby fulfilling the required interface.
