### PR TITLE
set Display.errch and use it for errors from mouse/keyboard

### DIFF
--- a/draw/init.go
+++ b/draw/init.go
@@ -88,6 +88,9 @@ func Init(errch chan<- error, fontname, label, winsize string) (*Display, error)
 	if err != nil {
 		return nil, err
 	}
+	if errch == nil {
+		errch = make(chan error)
+	}
 	d := &Display{
 		conn:    c,
 		errch:   errch,

--- a/draw/keyboard.go
+++ b/draw/keyboard.go
@@ -1,7 +1,5 @@
 package draw
 
-import "log"
-
 const (
 	KeyFn = '\uF000'
 
@@ -42,7 +40,11 @@ func kbdproc(d *Display, ch chan rune) {
 	for {
 		r, err := d.conn.ReadKbd()
 		if err != nil {
-			log.Fatal(err)
+			select {
+			case d.errch <- err:
+			default:
+			}
+			return
 		}
 		ch <- r
 	}

--- a/draw/mouse.go
+++ b/draw/mouse.go
@@ -3,7 +3,6 @@ package draw
 import (
 	"fmt"
 	"image"
-	"log"
 	"os"
 )
 
@@ -45,7 +44,11 @@ func mouseproc(mc *Mousectl, d *Display, ch chan Mouse, rch chan bool) {
 	for {
 		m, resized, err := d.conn.ReadMouse()
 		if err != nil {
-			log.Fatal(err)
+			select {
+			case d.errch <- err:
+			default:
+			}
+			return
 		}
 		if resized {
 			rch <- true


### PR DESCRIPTION
i've only seen error EOF from devdraw mouse/keyboard, when i close
a window (at least on macos), or by calling Display.Close().  before
this change, the draw lib would call log.Fatal, ending the entire
program.  now, it will send the error on errch.  it is the caller's
responsibility to pass an errch to Init() that has buffering, if
it wants to be sure it sees the errors.

this doesn't remove the "TODO use errch" comment at Init(), because
not all errors are handled yet. there are still some log.Fatal's,
around allocimage/allocwindow.

i need this for applications that create multiple windows over their lifetime. before this change, closing any window log.Fatal's the entire program. i am launching multiple devdraw's. perhaps it's possible (or should) be to have devdraw manage multiple windows?