### PR TITLE
draw: update test code for go test 1.10

### DIFF
--- a/draw/getsubfont.go
+++ b/draw/getsubfont.go
@@ -47,12 +47,12 @@ func scalesubfont(f *Subfont, scale int) {
 	dst := make([]byte, dstn)
 	i, err := f.Bits.Display.AllocImage(r2, f.Bits.Pix, false, Black)
 	if err != nil {
-		log.Fatal("allocimage: %v", err)
+		log.Fatalf("allocimage: %v", err)
 	}
 	for y := r.Min.Y; y < r.Max.Y; y++ {
 		_, err := f.Bits.Unload(image.Rect(r.Min.X, y, r.Max.X, y+1), src)
 		if err != nil {
-			log.Fatal("unloadimage: %v", err)
+			log.Fatalf("unloadimage: %v", err)
 		}
 		for i := range dst {
 			dst[i] = 0

--- a/draw/openfont.go
+++ b/draw/openfont.go
@@ -82,7 +82,7 @@ func (d *Display) openFont1(name string) (*Font, error) {
 
 func swapfont(targ *Font, oldp, newp **Font) {
 	if targ != *oldp {
-		log.Fatal("bad swapfont %p %p %p", targ, *oldp, *newp)
+		log.Fatalf("bad swapfont %p %p %p", targ, *oldp, *newp)
 	}
 
 	old := *oldp


### PR DESCRIPTION
go test 1.10 runs go vet prior to running the tests and so fails when
formatting directives are used as arguments to log.Fatal in draw
test code. Change these calls to log.Fatalf
