### PR TITLE
plumb: Always read entire message in plumb.Recv

### DIFF
--- a/plumb/plumb.go
+++ b/plumb/plumb.go
@@ -153,7 +153,16 @@ func (r *reader) readLine() string {
 func (r *reader) read(p []byte) {
 	rr, ok := r.r.(io.Reader)
 	if r.err == nil && ok {
-		_, r.err = rr.Read(p)
+		// io.Reader may return before p has been filled so loop until
+		// the entire message payload has been read into p.
+		for ro := 0; ro < len(p); {
+			n, err := rr.Read(p[ro:])
+			if err != nil {
+				r.err = err
+				break
+			}
+			ro += n
+		}
 		return
 	}
 	for i := range p {

--- a/plumb/plumb.go
+++ b/plumb/plumb.go
@@ -153,16 +153,7 @@ func (r *reader) readLine() string {
 func (r *reader) read(p []byte) {
 	rr, ok := r.r.(io.Reader)
 	if r.err == nil && ok {
-		// io.Reader may return before p has been filled so loop until
-		// the entire message payload has been read into p.
-		for ro := 0; ro < len(p); {
-			n, err := rr.Read(p[ro:])
-			if err != nil {
-				r.err = err
-				break
-			}
-			ro += n
-		}
+		_, r.err = io.ReadFull(rr, p)
 		return
 	}
 	for i := range p {


### PR DESCRIPTION
plumb.Recv reads plumber messages from an underlying io.Reader.
io.Reader implementations may choose to return less than the requested
number of bytes particularly when a plumber message is large (e.g.
plumb 'frame(3)') so use io.ReadFull to read the entire message.