### PR TITLE
plan9/client: make ReadAt compatible with io.ReaderAt interface

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"sort"
@@ -352,7 +353,7 @@ func (w *Win) ReadAddr() (q0, q1 int, err error) {
 	}
 	buf := make([]byte, 40)
 	n, err := f.ReadAt(buf, 0)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return 0, 0, err
 	}
 	a := strings.Fields(string(buf[0:n]))

--- a/plan9/client/fid.go
+++ b/plan9/client/fid.go
@@ -105,10 +105,25 @@ func (fid *Fid) Qid() plan9.Qid {
 }
 
 func (fid *Fid) Read(b []byte) (n int, err error) {
-	return fid.ReadAt(b, -1)
+	return fid.readAt(b, -1)
 }
 
 func (fid *Fid) ReadAt(b []byte, offset int64) (n int, err error) {
+	for len(b) > 0 {
+		m, err := fid.readAt(b, offset)
+		if err != nil {
+			return n, err
+		}
+		n += m
+		b = b[m:]
+		if offset != -1 {
+			offset += int64(m)
+		}
+	}
+	return n, nil
+}
+
+func (fid *Fid) readAt(b []byte, offset int64) (n int, err error) {
 	msize := fid.c.msize - plan9.IOHDRSZ
 	n = len(b)
 	if uint32(n) > msize {


### PR DESCRIPTION
Satisfy this requirement of io.ReaderAt:

    When ReadAt returns n < len(p), it returns a non-nil error
    explaining why more bytes were not returned.

In other words, when EOF is reached and 0 < n < len(p), io.EOF error
must be returned. ReadAt was delaying sending io.EOF until n == 0.

Satisfying io.ReaderAt makes it possible to substitute Fid with os.File
in Plan 9.