### PR TITLE
acme/Watch: kill child processes too

### DIFF
--- a/acme/Watch/main.go
+++ b/acme/Watch/main.go
@@ -185,10 +185,11 @@ func runner() {
 		id := run.id
 		run.Unlock()
 		if lastcmd != nil {
-			lastcmd.Process.Kill()
+			syscall.Kill(-lastcmd.Process.Pid, syscall.SIGKILL)
 		}
 		lastcmd = nil
 		cmd := exec.Command(args[0], args[1:]...)
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		r, w, err := os.Pipe()
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
This modification set the `setpgid` on the given cmd in order child processes will also be killed on file changes.