### PR TITLE
Fixed panic and build errors

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -866,7 +866,7 @@ func (w *Win) execute(h EventHandler, cmd string) bool {
 	out := m.Call(args)
 	var err error
 	if len(out) == 1 {
-		err = out[0].Interface().(error)
+		err, _ = out[0].Interface().(error)
 	}
 	if err != nil {
 		w.Errf("%v", err)

--- a/acme/acme.go
+++ b/acme/acme.go
@@ -838,7 +838,7 @@ func (w *Win) execute(h EventHandler, cmd string) bool {
 		// ok
 	case 1:
 		if t.Out(0) != reflect.TypeOf((*error)(nil)).Elem() {
-			w.Errf("bad method %s: return type %v, not error", t.Out(0))
+			w.Errf("bad method %s: return type %v, not error", cmd, t.Out(0))
 			return true
 		}
 	}

--- a/acme/acmego/main.go
+++ b/acme/acmego/main.go
@@ -110,7 +110,7 @@ func reformat(id int, name string) {
 		return
 	}
 	if !bytes.Equal(old, latest) {
-		log.Printf("skipped update to %s: window modified since Put\n", name, len(old), len(latest))
+		log.Printf("skipped update to %s: window modified since Put\n", name)
 		return
 	}
 


### PR DESCRIPTION
I've fixed panic when a method that has `ExecXxx(...) error` signature returned nil, and fixed detected errors by `go vet`.

goroutine dumps is:

```
panic: interface conversion: interface is nil, not error

goroutine 6 [running]:
9fans.net/go/acme.(*Win).execute(0xc0000f6000, 0x1245ca0, 0xc0000a0060, 0xc0000947c0, 0x3, 0x3)
	/Users/lufia/pkg/mod/9fans.net/go@v0.0.1/acme/acme.go:864 +0x496
9fans.net/go/acme.(*Win).EventLoop(0xc0000f6000, 0x1245ca0, 0xc0000a0060)
	/Users/lufia/pkg/mod/9fans.net/go@v0.0.1/acme/acme.go:796 +0x103
created by main.open
	/Users/lufia/pkg/mod/rsc.io/todo@v0.0.2/acme.go:110 +0x373
```

ref rsc/todo#1