### PR TITLE
draw: fix buffer size calculation in dopoly function

### DIFF
--- a/draw/poly.go
+++ b/draw/poly.go
@@ -35,7 +35,7 @@ func dopoly(cmd byte, dst *Image, pp []image.Point, end0, end1, radius int, src 
 	ox, oy := 0, 0
 	for _, p := range pp {
 		o += addcoord(a[o:], ox, p.X)
-		o = addcoord(a[o:], oy, p.Y)
+		o += addcoord(a[o:], oy, p.Y)
 		ox, oy = p.X, p.Y
 	}
 	d := dst.Display


### PR DESCRIPTION
This patch fixes an error in the dopoly function, where the buffer size o
is mistakenly set rather than added to. This causes the message buffer to
be truncated and the appearance of the error 'flush: short draw message
errors.'