### PR TITLE
draw: fix nil pointer dereference for (*Display).Close method

### DIFF
--- a/draw/buildfont.go
+++ b/draw/buildfont.go
@@ -88,7 +88,7 @@ Errbad:
 	return nil, fmt.Errorf("bad font format: number expected (char position %d)", len(buf)-len(s))
 }
 
-/// Free frees the server resources for the Font. Fonts have a finalizer that
+// Free frees the server resources for the Font. Fonts have a finalizer that
 // calls Free automatically, if necessary, for garbage collected Images, but it
 // is more efficient to be explicit.
 // TODO: Implement the Finalizer!

--- a/draw/init.go
+++ b/draw/init.go
@@ -267,11 +267,11 @@ func (d *Display) Attach(ref int) error {
 
 // Close closes the Display.
 func (d *Display) Close() error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
 	if d == nil {
 		return nil
 	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	return d.conn.Close()
 }
 
@@ -361,7 +361,7 @@ func bpshort(b []byte, n uint16) {
 }
 
 func (d *Display) HiDPI() bool {
-	return d.DPI >= DefaultDPI*3/2 
+	return d.DPI >= DefaultDPI*3/2
 }
 
 func (d *Display) ScaleSize(n int) int {


### PR DESCRIPTION
Fix a possible scenario when`d == nil`, dereferencing would cause `panic`.