### PR TITLE
draw, games: use image.Point{} instead of deprecated image.ZP

### DIFF
--- a/draw/allocimagemix.go
+++ b/draw/allocimagemix.go
@@ -12,7 +12,7 @@ func (d *Display) AllocImageMix(color1, color3 Color) *Image {
 	if d.ScreenImage.Depth <= 8 { // create a 2x2 texture
 		t, _ := d.allocImage(image.Rect(0, 0, 1, 1), d.ScreenImage.Pix, false, color1)
 		b, _ := d.allocImage(image.Rect(0, 0, 2, 2), d.ScreenImage.Pix, true, color3)
-		b.draw(image.Rect(0, 0, 1, 1), t, nil, image.ZP)
+		b.draw(image.Rect(0, 0, 1, 1), t, nil, image.Point{})
 		t.free()
 		return b
 	}
@@ -23,7 +23,7 @@ func (d *Display) AllocImageMix(color1, color3 Color) *Image {
 	}
 	t, _ := d.allocImage(image.Rect(0, 0, 1, 1), d.ScreenImage.Pix, true, color1)
 	b, _ := d.allocImage(image.Rect(0, 0, 1, 1), d.ScreenImage.Pix, true, color3)
-	b.draw(b.R, t, d.qmask, image.ZP)
+	b.draw(b.R, t, d.qmask, image.Point{})
 	t.free()
 	return b
 }

--- a/draw/init.go
+++ b/draw/init.go
@@ -169,7 +169,7 @@ func Init(errch chan<- error, fontname, label, winsize string) (*Display, error)
 	}
 
 	screen := d.ScreenImage
-	screen.draw(screen.R, d.White, nil, image.ZP)
+	screen.draw(screen.R, d.White, nil, image.Point{})
 	if err := d.flush(true); err != nil {
 		log.Fatal(err)
 	}
@@ -361,7 +361,7 @@ func bpshort(b []byte, n uint16) {
 }
 
 func (d *Display) HiDPI() bool {
-	return d.DPI >= DefaultDPI*3/2 
+	return d.DPI >= DefaultDPI*3/2
 }
 
 func (d *Display) ScaleSize(n int) int {

--- a/draw/string.go
+++ b/draw/string.go
@@ -9,7 +9,7 @@ import (
 func (dst *Image) String(pt image.Point, src *Image, sp image.Point, f *Font, s string) image.Point {
 	dst.Display.mu.Lock()
 	defer dst.Display.mu.Unlock()
-	return _string(dst, pt, src, sp, f, s, nil, nil, dst.Clipr, nil, image.ZP, SoverD)
+	return _string(dst, pt, src, sp, f, s, nil, nil, dst.Clipr, nil, image.Point{}, SoverD)
 }
 
 // StringOp draws the string in the specified font, placing the upper left corner at p.
@@ -17,7 +17,7 @@ func (dst *Image) String(pt image.Point, src *Image, sp image.Point, f *Font, s 
 func (dst *Image) StringOp(pt image.Point, src *Image, sp image.Point, f *Font, s string, op Op) image.Point {
 	dst.Display.mu.Lock()
 	defer dst.Display.mu.Unlock()
-	return _string(dst, pt, src, sp, f, s, nil, nil, dst.Clipr, nil, image.ZP, op)
+	return _string(dst, pt, src, sp, f, s, nil, nil, dst.Clipr, nil, image.Point{}, op)
 }
 
 // StringBg draws the string in the specified font, placing the upper left corner at p.
@@ -43,7 +43,7 @@ func (dst *Image) StringBgOp(pt image.Point, src *Image, sp image.Point, f *Font
 func (dst *Image) Runes(pt image.Point, src *Image, sp image.Point, f *Font, r []rune) image.Point {
 	dst.Display.mu.Lock()
 	defer dst.Display.mu.Unlock()
-	return _string(dst, pt, src, sp, f, "", nil, r, dst.Clipr, nil, image.ZP, SoverD)
+	return _string(dst, pt, src, sp, f, "", nil, r, dst.Clipr, nil, image.Point{}, SoverD)
 }
 
 // RunesOp draws the rune slice in the specified font, placing the upper left corner at p.
@@ -51,7 +51,7 @@ func (dst *Image) Runes(pt image.Point, src *Image, sp image.Point, f *Font, r [
 func (dst *Image) RunesOp(pt image.Point, src *Image, sp image.Point, f *Font, r []rune, op Op) image.Point {
 	dst.Display.mu.Lock()
 	defer dst.Display.mu.Unlock()
-	return _string(dst, pt, src, sp, f, "", nil, r, dst.Clipr, nil, image.ZP, op)
+	return _string(dst, pt, src, sp, f, "", nil, r, dst.Clipr, nil, image.Point{}, op)
 }
 
 // RunesBg draws the rune slice in the specified font, placing the upper left corner at p.
@@ -77,7 +77,7 @@ func (dst *Image) RunesBgOp(pt image.Point, src *Image, sp image.Point, f *Font,
 func (dst *Image) Bytes(pt image.Point, src *Image, sp image.Point, f *Font, b []byte) image.Point {
 	dst.Display.mu.Lock()
 	defer dst.Display.mu.Unlock()
-	return _string(dst, pt, src, sp, f, "", b, nil, dst.Clipr, nil, image.ZP, SoverD)
+	return _string(dst, pt, src, sp, f, "", b, nil, dst.Clipr, nil, image.Point{}, SoverD)
 }
 
 // BytesOp draws the byte slice in the specified font, placing the upper left corner at p.
@@ -85,7 +85,7 @@ func (dst *Image) Bytes(pt image.Point, src *Image, sp image.Point, f *Font, b [
 func (dst *Image) BytesOp(pt image.Point, src *Image, sp image.Point, f *Font, b []byte, op Op) image.Point {
 	dst.Display.mu.Lock()
 	defer dst.Display.mu.Unlock()
-	return _string(dst, pt, src, sp, f, "", b, nil, dst.Clipr, nil, image.ZP, op)
+	return _string(dst, pt, src, sp, f, "", b, nil, dst.Clipr, nil, image.Point{}, op)
 }
 
 // BytesBg draws the rune slice in the specified font, placing the upper left corner at p.

--- a/games/4s/xs.go
+++ b/games/4s/xs.go
@@ -220,8 +220,8 @@ func collider(pt, pmax image.Point) bool {
 }
 
 func setpiece(p *Piece) {
-	bb.Draw(bb.R, display.White, nil, image.ZP)
-	bbmask.Draw(bb.R, display.Transparent, nil, image.ZP)
+	bb.Draw(bb.R, display.White, nil, image.Point{})
+	bbmask.Draw(bb.R, display.Transparent, nil, image.Point{})
 	br = image.Rect(0, 0, 0, 0)
 	br2 = br
 	piece = p
@@ -237,9 +237,9 @@ func setpiece(p *Piece) {
 		r.Max.X = r.Min.X + pcsz
 		r.Max.Y = r.Min.Y + pcsz
 		if i == 0 {
-			bb.Draw(r, display.Black, nil, image.ZP)
-			bb.Draw(r.Inset(1), tx[piece.tx], nil, image.ZP)
-			bbmask.Draw(r, display.Opaque, nil, image.ZP)
+			bb.Draw(r, display.Black, nil, image.Point{})
+			bb.Draw(r.Inset(1), tx[piece.tx], nil, image.Point{})
+			bbmask.Draw(r, display.Opaque, nil, image.Point{})
 			op = r.Min
 		} else {
 			bb.Draw(r, bb, nil, op)
@@ -257,9 +257,9 @@ func setpiece(p *Piece) {
 	br2.Max = br.Max.Add(delta)
 	r = br.Add(bb2.R.Min)
 	r2 := br2.Add(bb2.R.Min)
-	bb2.Draw(r2, display.White, nil, image.ZP)
+	bb2.Draw(r2, display.White, nil, image.Point{})
 	bb2.Draw(r.Add(delta), bb, nil, bb.R.Min)
-	bb2mask.Draw(r2, display.Transparent, nil, image.ZP)
+	bb2mask.Draw(r2, display.Transparent, nil, image.Point{})
 	bb2mask.Draw(r, display.Opaque, bbmask, bb.R.Min)
 	bb2mask.Draw(r.Add(delta), display.Opaque, bbmask, bb.R.Min)
 }
@@ -267,7 +267,7 @@ func setpiece(p *Piece) {
 func drawpiece() {
 	screen.Draw(br.Add(pos), bb, bbmask, bb.R.Min)
 	if suspended {
-		screen.Draw(br.Add(pos), display.White, whitemask, image.ZP)
+		screen.Draw(br.Add(pos), display.White, whitemask, image.Point{})
 	}
 }
 
@@ -317,8 +317,8 @@ func canfit(p *Piece) bool {
 func score(p int) {
 	points += p
 	buf := fmt.Sprintf("%.6d", points)
-	screen.Draw(image.Rectangle{pscore, pscore.Add(scoresz)}, display.White, nil, image.ZP)
-	screen.String(pscore, display.Black, image.ZP, display.DefaultFont, buf)
+	screen.Draw(image.Rectangle{pscore, pscore.Add(scoresz)}, display.White, nil, image.Point{})
+	screen.String(pscore, display.Black, image.Point{}, display.DefaultFont, buf)
 }
 
 func drawsq(b *draw.Image, p image.Point, ptx int) {
@@ -326,14 +326,14 @@ func drawsq(b *draw.Image, p image.Point, ptx int) {
 	r.Min = p
 	r.Max.X = r.Min.X + pcsz
 	r.Max.Y = r.Min.Y + pcsz
-	b.Draw(r, display.Black, nil, image.ZP)
-	b.Draw(r.Inset(1), tx[ptx], nil, image.ZP)
+	b.Draw(r, display.Black, nil, image.Point{})
+	b.Draw(r.Inset(1), tx[ptx], nil, image.Point{})
 }
 
 func drawboard() {
-	screen.Border(rboard.Inset(-2), 2, display.Black, image.ZP)
+	screen.Border(rboard.Inset(-2), 2, display.Black, image.Point{})
 	screen.Draw(image.Rect(rboard.Min.X, rboard.Min.Y-2, rboard.Max.X, rboard.Min.Y),
-		display.White, nil, image.ZP)
+		display.White, nil, image.Point{})
 	for i := 0; i < NY; i++ {
 		for j := 0; j < NX; j++ {
 			if board[i][j] != 0 {
@@ -343,7 +343,7 @@ func drawboard() {
 	}
 	score(0)
 	if suspended {
-		screen.Draw(screenr, display.White, whitemask, image.ZP)
+		screen.Draw(screenr, display.White, whitemask, image.Point{})
 	}
 }
 
@@ -438,7 +438,7 @@ func horiz() bool {
 	for j := 0; j < h; j++ {
 		r.Min.Y = rboard.Min.Y + lev[j]*pcsz
 		r.Max.Y = r.Min.Y + pcsz
-		screen.Draw(r, display.White, whitemask, image.ZP)
+		screen.Draw(r, display.White, whitemask, image.Point{})
 		display.Flush()
 	}
 	for i := 0; i < 3; i++ {
@@ -450,7 +450,7 @@ func horiz() bool {
 		for j := 0; j < h; j++ {
 			r.Min.Y = rboard.Min.Y + lev[j]*pcsz
 			r.Max.Y = r.Min.Y + pcsz
-			screen.Draw(r, display.White, whitemask, image.ZP)
+			screen.Draw(r, display.White, whitemask, image.Point{})
 		}
 		display.Flush()
 	}
@@ -462,7 +462,7 @@ func horiz() bool {
 		r.Max.Y = rboard.Min.Y + lev[j]*pcsz
 		screen.Draw(r.Add(image.Pt(0, pcsz)), screen, nil, r.Min)
 		r.Max.Y = rboard.Min.Y + pcsz
-		screen.Draw(r, display.White, nil, image.ZP)
+		screen.Draw(r, display.White, nil, image.Point{})
 		for k := lev[j] - 1; k >= 0; k-- {
 			board[k+1] = board[k]
 		}
@@ -698,7 +698,7 @@ func redraw(new bool) {
 	bbmask, _ = display.AllocImage(image.Rect(0, 0, N*pcsz, N*pcsz), draw.GREY1, false, 0)
 	bb2, _ = display.AllocImage(image.Rect(0, 0, N*pcsz, N*pcsz+DY), screen.Pix, false, 0)
 	bb2mask, _ = display.AllocImage(image.Rect(0, 0, N*pcsz, N*pcsz+DY), draw.GREY1, false, 0)
-	screen.Draw(screenr, display.White, nil, image.ZP)
+	screen.Draw(screenr, display.White, nil, image.Point{})
 	drawboard()
 	setpiece(piece)
 	if piece != nil {

--- a/games/spacewar/spacewar.go
+++ b/games/spacewar/spacewar.go
@@ -106,7 +106,7 @@ func (m *SpacewarPDP1) Init(d *draw.Display) {
 		b = draw.Color(min(0, 255))
 		m.cmap[i], _ = d.AllocImage(image.Rect(0, 0, 1, 1), d.ScreenImage.Pix, true, r<<24|g<<16|b<<8|0xff)
 	}
-	m.screen.Draw(m.screen.R, d.Black, nil, image.ZP)
+	m.screen.Draw(m.screen.R, d.Black, nil, image.Point{})
 }
 
 const (
@@ -167,7 +167,7 @@ func (m *SpacewarPDP1) flush() {
 		for x := 0; x < m.dx; x++ {
 			if m.oldpix[y][x] != m.pix[y][x] {
 				r := image.Rect(x, y, x+1, y+1)
-				m.screen.Draw(r, m.cmap[m.pix[y][x]], nil, image.ZP)
+				m.screen.Draw(r, m.cmap[m.pix[y][x]], nil, image.Point{})
 				m.oldpix[y][x] = m.pix[y][x]
 			}
 			m.pix[y][x] >>= 1


### PR DESCRIPTION
Replace `image.ZP` with `image.Point{}`

Quoting from [image.Point](https://golang.org/pkg/image/#Point):
```
Deprecated: Use a literal image.Point{} instead.
```