### PR TITLE
plan9: avoid string(int) conversion

### DIFF
--- a/plan9/dir.go
+++ b/plan9/dir.go
@@ -130,7 +130,7 @@ type Perm uint32
 
 type permChar struct {
 	bit Perm
-	c   int
+	c   rune
 }
 
 var permChars = []permChar{
@@ -165,21 +165,21 @@ var permChars = []permChar{
 }
 
 func (p Perm) String() string {
-	s := ""
+	r := make([]rune, 0)
 	did := false
 	for _, pc := range permChars {
 		if p&pc.bit != 0 {
 			did = true
-			s += string(pc.c)
+			r = append(r, pc.c)
 		}
 		if pc.bit == 0 {
 			if !did {
-				s += string(pc.c)
+				r = append(r, pc.c)
 			}
 			did = false
 		}
 	}
-	return s
+	return string(r)
 }
 
 func gperm(b []byte) (Perm, []byte) {


### PR DESCRIPTION
Converted `permChar.c`'s type to rune to avoid the `string(int)` conversion warning flagged by `go vet` in Go 1.15. Well I could have just typecasted `int` to `rune` because all `permChar.c` mentioned in the `dir.go` are valid and won't be an issue even if I went with that fix. But I went with the following change as it was making more sense to me.

Ref: [Go Issue #32479](https://github.com/golang/go/issues/32479)
