### PR TITLE
plan9: change permChar c field from int to rune

### DIFF
--- a/plan9/dir.go
+++ b/plan9/dir.go
@@ -130,7 +130,7 @@ type Perm uint32
 
 type permChar struct {
 	bit Perm
-	c   int
+	c   rune
 }
 
 var permChars = []permChar{


### PR DESCRIPTION
very small fix to get rid of this error
```
plan9/dir.go:173:9: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```