### PR TITLE
Editinacme: Create nonexistent files instead of erroring out

### DIFF
--- a/acme/editinacme/main.go
+++ b/acme/editinacme/main.go
@@ -13,6 +13,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -36,8 +37,17 @@ func main() {
 	}
 
 	file := flag.Arg(0)
+
+	var perr *os.PathError
 	_, err := os.Stat(file)
-	if err != nil {
+	if errors.As(err, &perr) {
+		// File probably does not exist, try creating it so Acme doesn't complain
+		fh, err := os.Create(file)
+		if err != nil {
+			log.Fatalf("can't create file: %s", err)
+		}
+		fh.Close()
+	} else if err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
This makes it easier to replace my brain's "type vi to create a file"
reflex with "type editinacme for all sorts of editing stuff".