### PR TITLE
acme/Watch: use kill() to terminate the last running command

### DIFF
--- a/acme/Watch/main.go
+++ b/acme/Watch/main.go
@@ -161,7 +161,7 @@ func runner() {
 		run.kill = false
 		run.Unlock()
 		if lastcmd != nil {
-			lastcmd.Process.Kill()
+			kill(lastcmd)
 		}
 		lastcmd = nil
 


### PR DESCRIPTION
Using kill() avoids child processes to stay running in the background.
This is specially relevant when running programs like servers, which
have to be terminated explicitly. If they are not killed, processes
would be leaked or successive runs could fail due to unreleased
resources (e.g. network ports).

For instance, when developing simple servers, I commonly run Watch
this way:

```
Watch -r 'go build && ./server -addr=:6060' 
```

If child processes are not killed, next runs would fail because the
listen address is still in use. The changes introduced in this pull
request allow to restart the server when changing files or executing
Get.