### PR TITLE
acme: avoid crash when w.fid fails

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -324,10 +324,10 @@ func (w *Win) fid(name string) (*client.Fid, error) {
 // ReadAll
 func (w *Win) ReadAll(file string) ([]byte, error) {
 	f, err := w.fid(file)
-	f.Seek(0, 0)
 	if err != nil {
 		return nil, err
 	}
+	f.Seek(0, 0)
 	return ioutil.ReadAll(f)
 }
 


### PR DESCRIPTION
This fixes an occasional panic I was seeing when using `acmego`. @rsc 