### PR TITLE
cmd/acme: fix Edit pipe deadlock

### DIFF
--- a/cmd/acme/acme.go
+++ b/cmd/acme/acme.go
@@ -586,8 +586,8 @@ func mousethread() {
  */
 
 type Proc struct {
-	proc  *os.Process
-	err error
+	proc *os.Process
+	err  error
 	next *Proc
 }
 
@@ -629,7 +629,7 @@ func waitthread() {
 		case w := <-exec.Cwait:
 			bigLock()
 			proc := w.Proc
-			var c, lc *exec.Command
+			var lc *exec.Command
 			for c = command; c != nil; c = c.Next {
 				if c.Proc == proc {
 					if lc != nil {
@@ -696,7 +696,6 @@ func waitthread() {
 	Freecmd:
 		if c != nil {
 			if c.IsEditCmd {
-println("Cedit send")
 				editpkg.Cedit <- 0
 			}
 			fsysdelid(c.Mntdir)

--- a/cmd/acme/internal/edit/ecmd.go
+++ b/cmd/acme/internal/edit/ecmd.go
@@ -554,6 +554,7 @@ func runpipe(t *wind.Text, cmd rune, cr []rune, state int) {
 	wind.TheRow.Lk.Unlock()
 	BigUnlock()
 	<-Cedit
+
 	BigLock()
 	var q *util.QLock
 	/*
@@ -572,8 +573,10 @@ func runpipe(t *wind.Text, cmd rune, cr []rune, state int) {
 	} else {
 		q = &Editoutlk
 	}
+	BigUnlock()
 	q.Lock() // wait for file to close
 	q.Unlock()
+	BigLock()
 	wind.TheRow.Lk.Lock()
 	Editing = Inactive
 	if t != nil && t.W != nil {

--- a/cmd/acme/internal/exec/exec.go
+++ b/cmd/acme/internal/exec/exec.go
@@ -1104,6 +1104,7 @@ func runwaittask(c *Command, cproc chan *os.Process) {
 	if c.Proc != nil { // successful exec
 		Ccommand <- c
 	} else if c.IsEditCmd {
+		// Avoid deadlock when we can't execute the command.
 		edit.Cedit <- 0
 	}
 }

--- a/cmd/acme/internal/util/util.go
+++ b/cmd/acme/internal/util/util.go
@@ -16,8 +16,8 @@ package util
 
 import (
 	"log"
-	"sync/atomic"
 	"sync"
+	"sync/atomic"
 )
 
 func Min(a int, b int) int {
@@ -39,7 +39,7 @@ func Fatal(s string) {
 }
 
 var locks struct {
-	mu sync.Mutex
+	mu   sync.Mutex
 	cond sync.Cond
 }
 

--- a/cmd/internal/base/dat.h.go
+++ b/cmd/internal/base/dat.h.go
@@ -5,5 +5,9 @@ type Mntdir struct {
 	Ref  int
 	Dir  []rune
 	Next *Mntdir
+	// Incl holds include directories as added by the Incl command.
+	// This is present so that warning messages issued by
+	// commands can create windows that have the correct
+	// include directories (see ../../acme/acme.go:/<-exec.Ccommand)
 	Incl [][]rune
 }


### PR DESCRIPTION
Two bugs.
One is a lexical issue, with the obvious fix.

The other is a bigLock issue, and I applied the obvious
fix to drop the lock while the qlock is being obtained,
but I'm not entirely sure that it's the correct fix.

Plus a few other minor drive-by comments and syntactic changes.