### PR TITLE
plan9/client: refcounted Fsys

### DIFF
--- a/plan9/client/conn.go
+++ b/plan9/client/conn.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 
 	"9fans.net/go/plan9"
 )
@@ -13,29 +14,89 @@ type Error string
 func (e Error) Error() string { return string(e) }
 
 type Conn struct {
-	rwc     io.ReadWriteCloser
-	err     error
-	tagmap  map[uint16]chan *plan9.Fcall
-	freetag map[uint16]bool
-	freefid map[uint32]bool
-	nexttag uint16
-	nextfid uint32
-	msize   uint32
-	version string
-	r, w, x sync.Mutex
-	muxer   bool
+	// We wrap the underlying conn type so that
+	// there's a clear distinction between Close,
+	// which forces a close of the underlying rwc,
+	// and Release, which lets the Fids take control
+	// of when the conn is actually closed.
+	mu       sync.Mutex
+	_c       *conn
+	released bool
+}
+
+var errClosed = fmt.Errorf("connection has been closed")
+
+// Close forces a close of the connection and all Fids derived
+// from it.
+func (c *Conn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c._c == nil {
+		if c.released {
+			return fmt.Errorf("cannot close connection after it's been released")
+		}
+		return nil
+	}
+	rwc := c._c.rwc
+	c._c = nil
+	// TODO perhaps we shouldn't hold the mutex while closing?
+	return rwc.Close()
+}
+
+func (c *Conn) conn() (*conn, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c._c == nil {
+		return nil, errClosed
+	}
+	return c._c, nil
+}
+
+// Release marks the connection so that it will
+// close automatically when the last Fid derived
+// from it is closed.
+//
+// If there are no current Fids, it closes immediately.
+// After calling Release, c.Attach, c.Auth and c.Close will return
+// an error.
+func (c *Conn) Release() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c._c == nil {
+		return nil
+	}
+	conn := c._c
+	c._c = nil
+	c.released = true
+	return conn.release()
+}
+
+type conn struct {
+	rwc      io.ReadWriteCloser
+	err      error
+	tagmap   map[uint16]chan *plan9.Fcall
+	freetag  map[uint16]bool
+	freefid  map[uint32]bool
+	nexttag  uint16
+	nextfid  uint32
+	msize    uint32
+	version  string
+	w, x     sync.Mutex
+	muxer    bool
+	refCount int32 // atomic
 }
 
 func NewConn(rwc io.ReadWriteCloser) (*Conn, error) {
-	c := &Conn{
-		rwc:     rwc,
-		tagmap:  make(map[uint16]chan *plan9.Fcall),
-		freetag: make(map[uint16]bool),
-		freefid: make(map[uint32]bool),
-		nexttag: 1,
-		nextfid: 1,
-		msize:   131072,
-		version: "9P2000",
+	c := &conn{
+		rwc:      rwc,
+		tagmap:   make(map[uint16]chan *plan9.Fcall),
+		freetag:  make(map[uint16]bool),
+		freefid:  make(map[uint32]bool),
+		nexttag:  1,
+		nextfid:  1,
+		msize:    131072,
+		version:  "9P2000",
+		refCount: 1,
 	}
 
 	//	XXX raw messages, not c.rpc
@@ -59,36 +120,42 @@ func NewConn(rwc io.ReadWriteCloser) (*Conn, error) {
 	if rx.Version != "9P2000" {
 		return nil, plan9.ProtocolError(fmt.Sprintf("invalid version %s in Rversion", rx.Version))
 	}
-	return c, nil
+	return &Conn{
+		_c: c,
+	}, nil
 }
 
-func (c *Conn) newfid() (*Fid, error) {
+func (c *conn) newFid(fid uint32, qid plan9.Qid) *Fid {
+	c.acquire()
+	return &Fid{
+		_c:  c,
+		fid: fid,
+		qid: qid,
+	}
+}
+
+func (c *conn) newfidnum() (uint32, error) {
 	c.x.Lock()
 	defer c.x.Unlock()
-	var fidnum uint32
-	for fidnum, _ = range c.freefid {
+	for fidnum, _ := range c.freefid {
 		delete(c.freefid, fidnum)
-		goto found
+		return fidnum, nil
 	}
-	fidnum = c.nextfid
+	fidnum := c.nextfid
 	if c.nextfid == plan9.NOFID {
-		return nil, plan9.ProtocolError("out of fids")
+		return 0, plan9.ProtocolError("out of fids")
 	}
 	c.nextfid++
-found:
-	return &Fid{fid: fidnum, c: c}, nil
+	return fidnum, nil
 }
 
-func (c *Conn) putfid(f *Fid) {
+func (c *conn) putfidnum(fid uint32) {
 	c.x.Lock()
 	defer c.x.Unlock()
-	if f.fid != 0 && f.fid != plan9.NOFID {
-		c.freefid[f.fid] = true
-		f.fid = plan9.NOFID
-	}
+	c.freefid[fid] = true
 }
 
-func (c *Conn) newtag(ch chan *plan9.Fcall) (uint16, error) {
+func (c *conn) newtag(ch chan *plan9.Fcall) (uint16, error) {
 	c.x.Lock()
 	defer c.x.Unlock()
 	var tagnum uint16
@@ -110,7 +177,7 @@ found:
 	return tagnum, nil
 }
 
-func (c *Conn) puttag(tag uint16) chan *plan9.Fcall {
+func (c *conn) puttag(tag uint16) chan *plan9.Fcall {
 	c.x.Lock()
 	defer c.x.Unlock()
 	ch := c.tagmap[tag]
@@ -119,7 +186,7 @@ func (c *Conn) puttag(tag uint16) chan *plan9.Fcall {
 	return ch
 }
 
-func (c *Conn) mux(rx *plan9.Fcall) {
+func (c *conn) mux(rx *plan9.Fcall) {
 	c.x.Lock()
 	defer c.x.Unlock()
 
@@ -135,7 +202,7 @@ func (c *Conn) mux(rx *plan9.Fcall) {
 	ch <- rx
 }
 
-func (c *Conn) read() (*plan9.Fcall, error) {
+func (c *conn) read() (*plan9.Fcall, error) {
 	if err := c.getErr(); err != nil {
 		return nil, err
 	}
@@ -147,7 +214,7 @@ func (c *Conn) read() (*plan9.Fcall, error) {
 	return f, nil
 }
 
-func (c *Conn) write(f *plan9.Fcall) error {
+func (c *conn) write(f *plan9.Fcall) error {
 	if err := c.getErr(); err != nil {
 		return err
 	}
@@ -160,18 +227,37 @@ func (c *Conn) write(f *plan9.Fcall) error {
 
 var yourTurn plan9.Fcall
 
-func (c *Conn) rpc(tx *plan9.Fcall) (rx *plan9.Fcall, err error) {
+func (c *conn) rpc(tx *plan9.Fcall, clunkFid *Fid) (rx *plan9.Fcall, err error) {
 	ch := make(chan *plan9.Fcall, 1)
 	tx.Tag, err = c.newtag(ch)
 	if err != nil {
 		return nil, err
 	}
 	c.w.Lock()
-	if err := c.write(tx); err != nil {
-		c.w.Unlock()
-		return nil, err
+	err = c.write(tx)
+	// Mark the fid as clunked inside the write lock so that we're
+	// sure that we don't reuse it after the sending the message
+	// that will clunk it, even in the presence of concurrent method
+	// calls on Fid.
+	if clunkFid != nil {
+		// Closing the Fid might release the conn, which
+		// would close the underlying rwc connection,
+		// which would prevent us from being able to receive the
+		// reply, so make sure that doesn't happen until the end
+		// by acquiring a reference for the duration of the call.
+		c.acquire()
+		defer c.release()
+		if err := clunkFid.clunked(); err != nil {
+			// This can happen if two clunking operations
+			// (e.g. Close and Remove) are invoked concurrently
+			c.w.Unlock()
+			return nil, err
+		}
 	}
 	c.w.Unlock()
+	if err != nil {
+		return nil, err
+	}
 
 	for rx = range ch {
 		if rx != &yourTurn {
@@ -196,19 +282,27 @@ func (c *Conn) rpc(tx *plan9.Fcall) (rx *plan9.Fcall, err error) {
 	return rx, nil
 }
 
-func (c *Conn) Close() error {
-	return c.rwc.Close()
+func (c *conn) acquire() {
+	atomic.AddInt32(&c.refCount, 1)
 }
 
-func (c *Conn) getErr() error {
-	c.x.Lock()
-	err := c.err
-	c.x.Unlock()
+func (c *conn) release() error {
+	if atomic.AddInt32(&c.refCount, -1) != 0 {
+		return nil
+	}
+	err := c.rwc.Close()
+	c.setErr(errClosed)
 	return err
 }
 
-func (c *Conn) setErr(err error) {
+func (c *conn) getErr() error {
 	c.x.Lock()
+	defer c.x.Unlock()
+	return c.err
+}
+
+func (c *conn) setErr(err error) {
+	c.x.Lock()
+	defer c.x.Unlock()
 	c.err = err
-	c.x.Unlock()
 }


### PR DESCRIPTION
Implement `Fsys.Close` by closing its root `Fid`.

This needed a bunch of reworking to make refcounting of connections
work. We add a new method, `Conn.Release` which allows the
connection to be released when the last `Fid` derived from it
has been closed. The existing `Conn.Close` method retains its
old semantics for backward compatibility (arguably it might be better to change its semantics
and just let callers close the underlying connection directly themselves if they wish).

The closing logic was made more complex by the fact that a `Fid` could
represent both a fid that's been allocated on the server and a
fid that is about to be sent to the server for allocation.
Simplify the invariants by only creating a `Fid` object when we know
that the fid has actually been allocated on the server.

Also guard against concurrent method `Fid` method calls by atomically
closing the fid at exactly the moment we're sure that it will be clunked
(while we hold the write lock, just before sending the RPC request).