### PR TITLE
cmd/acme/internal/edit: fix infinite loop

### DIFF
--- a/cmd/acme/internal/edit/ecmd.go
+++ b/cmd/acme/internal/edit/ecmd.go
@@ -1212,6 +1212,11 @@ func lineaddr(l int, addr Address, sign int) Address {
 			a.r.Pos = p
 		}
 		for p < f.Len() {
+			c := f.Curtext.RuneAt(p)
+			p++
+			if c == '\n' {
+				break
+			}
 		}
 		a.r.End = p
 	} else {


### PR DESCRIPTION
I copied the logic from the C version:

```
		while(p < f->b.nc && textreadc(f->curtext, p++)!='\n')
			;
```
