### PR TITLE
acme/acmego: allow append at 0

### DIFF
--- a/acme/acmego/main.go
+++ b/acme/acmego/main.go
@@ -178,7 +178,7 @@ func reformat(id int, name string, formatter []string) {
 		}
 		oldStart, oldEnd := parseSpan(line[:j])
 		newStart, newEnd := parseSpan(line[j+1:])
-		if oldStart == 0 || newStart == 0 {
+		if newStart == 0 || (oldStart == 0 && line[j] != 'a') {
 			continue
 		}
 		switch line[j] {


### PR DESCRIPTION
When a line is being added to the start of a document
(a classic example being when `gofmt` adds a `//go:build` line),
the diff logic was ignoring it and thus always thinking that
the file needed changes without ever actually applying the
changes.