### PR TITLE
acmego: Add more formatters

### DIFF
--- a/acme/acmego/main.go
+++ b/acme/acmego/main.go
@@ -21,6 +21,14 @@
 // The other known extensions and formatters are:
 //
 //	.rs - rustfmt
+//	.ml - ocamlformat
+//	.re - refmt
+//	.svelte - prettier
+//	.js - prettier
+//	.ts - prettier
+//	.html - prettier
+//	.json - prettier
+//	.css - prettier
 //
 package main
 
@@ -47,7 +55,15 @@ var formatters = map[string][]string{
 
 // Non-Go formatters (only loaded with -f option).
 var otherFormatters = map[string][]string{
-	".rs": []string{"rustfmt", "--emit", "stdout"},
+	".rs":     []string{"rustfmt", "--emit", "stdout"},
+	".ml":     []string{"ocamlformat"},
+	".re":     []string{"refmt"},
+	".js":     []string{"prettier", "--loglevel", "silent"},
+	".ts":     []string{"prettier", "--loglevel", "silent"},
+	".html":   []string{"prettier", "--loglevel", "silent"},
+	".json":   []string{"prettier", "--loglevel", "silent"},
+	".css":    []string{"prettier", "--loglevel", "silent"},
+	".svelte": []string{"prettier", "--loglevel", "silent"},
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	golang.org/x/sys v0.0.0-20210415045647-66c3f260301c
 )
 
-replace 9fans.net/go => github.com/zakkor/go
+replace 9fans.net/go v0.0.4 => github.com/zakkor/go v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	golang.org/x/mobile v0.0.0-20210220033013-bdb1ca9a1e08
 	golang.org/x/sys v0.0.0-20210415045647-66c3f260301c
 )
+
+replace 9fans.net/go => github.com/zakkor/go


### PR DESCRIPTION
Adds formatters for: OCaml, ReasonML, Svelte, JavaScript, TypeScript, HTML, JSON, CSS