### PR TITLE
fix change in return value of syscall.Open(extstart in unix.go)

### DIFF
--- a/cmd/samterm/sys.go
+++ b/cmd/samterm/sys.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"syscall"
 
 	"9fans.net/go/draw"
 	"9fans.net/go/plan9"
@@ -77,10 +78,10 @@ func removeextern() {
 	os.Remove(exname)
 }
 
-func extproc(c chan string, fd *os.File) {
+func extproc(c chan string, fd int) {
 	buf := make([]byte, READBUFSIZE)
 	for {
-		n, err := fd.Read(buf)
+		n, err := syscall.Read(fd, buf)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "samterm: extern read error: %v\n", err)
 			return /* not a fatal error */

--- a/cmd/samterm/unix.go
+++ b/cmd/samterm/unix.go
@@ -1,3 +1,4 @@
+//go:build unix
 // +build unix
 
 package main


### PR DESCRIPTION
When trying to run `go install 9fans.net/go/...@latest` I recieved the following error:
`go/pkg/mod/9fans.net/go@v0.0.4/cmd/samterm/unix.go:62:21: cannot use fd (variable of type int) as type *os.File in argument to extproc`
It appears that the value of `syscall.Open` in the function `extstart` in `go/cmd/samterm/unix.go:43:12` has changed from `*os.File` to an integer, and so breaking the parameter passed to `extproc` in `sys.go`.
My commit fixes this by adding the `syscall` import to sys.go and using the function `syscall.Read`.