### PR TITLE
acme/Watch: use explicit directory for running command

### DIFF
--- a/acme/Watch/main.go
+++ b/acme/Watch/main.go
@@ -84,7 +84,7 @@ func main() {
 
 	needrun <- true
 	go events()
-	go runner()
+	go runner(pwd)
 
 	r, err := acme.Log()
 	if err != nil {
@@ -152,7 +152,7 @@ var run struct {
 	kill bool
 }
 
-func runner() {
+func runner(dir string) {
 	for range needrun {
 		run.Lock()
 		run.id++
@@ -167,7 +167,7 @@ func runner() {
 		lastcmd = nil
 
 		runSetup(id)
-		go runBackground(id)
+		go runBackground(id, dir)
 	}
 }
 
@@ -206,7 +206,7 @@ func runSetup(id int) {
 	win.Addr("#0")
 }
 
-func runBackground(id int) {
+func runBackground(id int, dir string) {
 	buf := make([]byte, 4096)
 	run.Lock()
 	for {
@@ -259,6 +259,7 @@ func runBackground(id int) {
 		}
 
 		cmd := exec.Command(rc, "-c", string(line))
+		cmd.Dir = dir
 		r, w, err := os.Pipe()
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
I've found that it's not uncommon to be running Watch in a VCS directory, and in the course of rebasing, that directory is removed and created again. Because the Watch command is just run in the current directory, that causes it to fail.

This change uses an explicit directory for the command, which fixes that failure. A more complete solution would probably take the directory from the window's tag, but that would be more involved, because we'd also want to change the watched directory when that changes, so leave it for later.