### PR TITLE
fix compilation error on samterm

### DIFF
--- a/cmd/samterm/unix.go
+++ b/cmd/samterm/unix.go
@@ -59,7 +59,7 @@ func extstart() {
 	}
 
 	plumbc = make(chan string)
-	go extproc(plumbc, fd)
+	go extproc(plumbc, os.NewFile(uintptr(fd), exname))
 	// atexit(removeextern)
 	return
 


### PR DESCRIPTION
I'm not well-versed on the subtleties around fd ints and the syscall package in go, but I was getting this error while trying to install the utils via `go install ./...`:
```
% go install ./...
# 9fans.net/go/cmd/samterm
cmd/samterm/unix.go:62:21: cannot use fd (variable of type int) as *os.File value in argument to extproc
```