### PR TITLE
acmego: allow arbitrary rc filters enclosed in [[ ]]

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -453,6 +453,15 @@ func (w *Win) Info() (WinInfo, error) {
 	); err != nil {
 		return WinInfo{}, fmt.Errorf("invalid ctl contents %q: %v", line, err)
 	}
+	f, err = w.fid("tag")
+	if err != nil {
+		return WinInfo{}, err
+	}
+	tag := make([]byte, info.TagLen)
+	if _, err := f.ReadFull(tag); err != nil {
+		return WinInfo{}, err
+	}
+	info.Tag = string(tag)
 	return info, nil
 }
 


### PR DESCRIPTION
I would like to automatically run `clang-format` on some but not all C files I edit. Not every project uses it and I don't want to mess up an entire file while making a one-line change.

This commit adds a new `[[filter]]` syntax for the tag. In my case I would write `[[clang-format]]` into the tag of my C file and then when I hit Put, acmego runs `rc -c 'clang-format $1' /path/to/file.c`.

To avoid conflicts with Edit, we ignore `[[` if it occurs after Edit. 

I don't know if this commit is the ideal design but I think acmego ought to be able to do something like this. It would elevate it to the same level of flexibility as Watch.