### PR TITLE
Use clang-format for .c and .h files

### DIFF
--- a/acme/acmego/main.go
+++ b/acme/acmego/main.go
@@ -69,10 +69,11 @@ func findClangFormatFile(path string) bool {
 
 // Non-Go formatters (only loaded with -f option).
 var otherFormatters = map[string]formatter{
-	".py": {[]string{"yapf"}, enabledAlways},
-	".rs": {[]string{"rustfmt", "--emit", "stdout"}, enabledAlways},
-	".c":  {[]string{"clang-format"}, findClangFormatFile},
-	".h":  {[]string{"clang-format"}, findClangFormatFile},
+	".py":  {[]string{"yapf"}, enabledAlways},
+	".rs":  {[]string{"rustfmt", "--emit", "stdout"}, enabledAlways},
+	".c":   {[]string{"clang-format"}, findClangFormatFile},
+	".h":   {[]string{"clang-format"}, findClangFormatFile},
+	".cpp": {[]string{"clang-format"}, findClangFormatFile},
 }
 
 func main() {


### PR DESCRIPTION
Because clang-format is not used universally, this change adds a check so that we only run clang-format if a .clang-format file can be found higher up in the directory tree.

This is an alternative approach to #111. I find it gets tedious to define a filter for each file I open.