### PR TITLE
cmd/samterm: Update Mkfifo calls to use unix package

### DIFF
--- a/cmd/samterm/unix.go
+++ b/cmd/samterm/unix.go
@@ -22,7 +22,7 @@ func extstart() {
 	} else {
 		exname = fmt.Sprintf("/tmp/.sam.%s", user)
 	}
-	err := syscall.Mkfifo(exname, 0600)
+	err := unix.Mkfifo(exname, 0600)
 	if err != nil {
 		if !os.IsExist(err) {
 			return
@@ -33,7 +33,7 @@ func extstart() {
 		}
 		if st.Mode()&fs.ModeNamedPipe == 0 {
 			removeextern()
-			if err := syscall.Mkfifo(exname, 0600); err != nil {
+			if err := unix.Mkfifo(exname, 0600); err != nil {
 				return
 			}
 		}


### PR DESCRIPTION
The samterm code calls syscall.Mkfifo in two places.  When compiling on AIX, this results in a compilation error:

$ go install
./unix.go:25:17: undefined: syscall.Mkfifo
./unix.go:36:22: undefined: syscall.Mkfifo

This is because the Mkfifo call is not implemented for AIX in the syscall package.  However, Mkfifo is available in the unix package, which is already imported in cmd/samterm/unix.go.  This change uses the Mkfifo from unix instead of syscall.

Fixes #123