### PR TITLE
acmego: fix line deletions at beginning of a file

### DIFF
--- a/acme/acmego/main.go
+++ b/acme/acmego/main.go
@@ -180,7 +180,7 @@ func reformat(id int, name string, formatter []string) {
 		}
 		oldStart, oldEnd := parseSpan(line[:j])
 		newStart, newEnd := parseSpan(line[j+1:])
-		if newStart == 0 || (oldStart == 0 && line[j] != 'a') {
+		if newStart == 0 && line[j] != 'd' || oldStart == 0 && line[j] != 'a' {
 			continue
 		}
 		switch line[j] {


### PR DESCRIPTION
If the formatter deletes 1 (or more) lines in the beginning of a file, the corresponding diff output records this with for example "1d0".

Until now, the trailing "0" tripped off the logic and the code just didn't apply such a deletion. This is now fixed by ignoring the trailing "0" for line deletion markers.