### PR TITLE
draw/plan9: correct Msec type, White/Black fields, add Cursor2 fallback

### DIFF
--- a/draw/drawfcall/mux_plan9.go
+++ b/draw/drawfcall/mux_plan9.go
@@ -163,6 +163,11 @@ func (c *Conn) Cursor(cursor *Cursor) error {
 	return err
 }
 
+// Cursor2 on Plan 9: gracefully degrade to legacy Cursor.
+func (c *Conn) Cursor2(cur *Cursor, cur2 *Cursor2) error {
+	return c.Cursor(cur)
+}
+
 func (c *Conn) BounceMouse(m *Mouse) error {
 	panic("unimplemented")
 }

--- a/draw/drawfcall/mux_plan9.go
+++ b/draw/drawfcall/mux_plan9.go
@@ -128,7 +128,7 @@ func (c *Conn) ReadMouse() (m Mouse, resized bool, err error) {
 	}
 	m.Point = image.Pt(atoi(f[1]), atoi(f[2]))
 	m.Buttons = atoi(f[3])
-	m.Msec = atoi(f[4])
+	m.Msec = uint32(atoi(f[4]))
 	if f[0] == "r" {
 		resized = true
 	}
@@ -151,14 +151,14 @@ func (c *Conn) Cursor(cursor *Cursor) error {
 		_, err := c.cursor.Write([]byte{0})
 		return err
 	}
-	b := make([]byte, 2*4+len(cursor.Clr)+len(cursor.Set))
+	b := make([]byte, 2*4+len(cursor.White)+len(cursor.Black))
 	i := 0
 	binary.LittleEndian.PutUint32(b[i:], uint32(cursor.Point.X))
 	i += 4
 	binary.LittleEndian.PutUint32(b[i:], uint32(cursor.Point.Y))
 	i += 4
-	i += copy(b[i:], cursor.Clr[:])
-	i += copy(b[i:], cursor.Set[:])
+	i += copy(b[i:], cursor.White[:])
+	i += copy(b[i:], cursor.Black[:])
 	_, err := c.cursor.Write(b)
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module 9fans.net/go
+module github.com/mushkevych/9fans-go
 
 go 1.23.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mushkevych/9fans-go
+module 9fans.net/go
 
 go 1.23.0
 


### PR DESCRIPTION
This PR corrects issues in the Plan 9 draw package that affects consumer of its mouse and cursor functionality:

* Mouse timestamp type – `Mouse.Msec` is defined as `uint32` but was assigned from an `int`. Fixed by casting to `uint32`.

* `Cursor` buffer packing – Updated to use the canonical `White/Black` fields instead of the obsolete `Clr/Set`, ensuring correct buffer sizing and rendering.

* `Cursor2` fallback – Added a safe fallback to `Cursor` on systems without *hi-DPI* support, so callers using `Cursor2` degrade gracefully.