### PR TITLE
drawfcall: ReadSnarf to return bytes read if buffer length was not big enough

### DIFF
--- a/draw/drawfcall/mux.go
+++ b/draw/drawfcall/mux.go
@@ -1,4 +1,4 @@
-// +build !plan9
+//go:build !plan9
 
 package drawfcall
 
@@ -250,10 +250,7 @@ func (c *Conn) ReadSnarf(b []byte) (int, int, error) {
 		return 0, 0, err
 	}
 	n := copy(b, rx.Snarf)
-	if n < len(rx.Snarf) {
-		return 0, len(rx.Snarf), nil
-	}
-	return n, n, nil
+	return n, len(rx.Snarf), nil
 }
 
 func (c *Conn) WriteSnarf(snarf []byte) error {


### PR DESCRIPTION
sometimes it is ok to get at least a portion of actual snarf buffer, e.g. to show to user what kind of data is stored in snarf. i want to use a small (1kb or less) buffer to read the beginning of the snarf and decide myself if it is an error that the buffer was not big enough to fit the whole snarf. 